### PR TITLE
Oracle Enterprise Linux compatbility.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,23 +8,33 @@
     state: directory
   when: 'docker_registry_storage_directory | length > 0'
 
+# Note: Oracle Enterprise Linux doesn't come with the python2 yum & rpm bindings
+# required for the docker_image module.
+- name: docker registry | pull registry image
+  become: yes
+  shell: docker pull registry:{{ docker_registry_version }}
+  when: ansible_distribution == "OracleLinux"
+
 # Needed for Ansible docker_image module
 - name: docker registry | docker-python
   become: yes
   yum:
     name: docker-python
     state: present
+  when: ansible_distribution != "OracleLinux"
 
 - name: docker registry | pull registry image
   become: yes
   docker_image:
     name: registry:{{ docker_registry_version }}
+  when: ansible_distribution != "OracleLinux"
 
 - name: docker registry | systemd service file
   become: yes
   template:
     src: systemd-system-docker-registry-service.j2
     dest: /etc/systemd/system/docker-registry.service
+    mode: 0755
   notify:
     - restart docker-registry
 


### PR DESCRIPTION
This PR adds compatibility for Oracle Enterprise Linux 7 via a special-case OS-dependent workaround for the error included below.

Oracle EL7 doesn't come with python2 bindings installed for yum, which causes Ansible to explode spectacularly when the docker_image module is used.

```bash
TASK [docker-registry : docker registry | docker-python] *************************************************************************************************************************************************************************************
task path: roles/docker-registry/tasks/main.yml:12
Using module file /venv/lib/python2.7/site-packages/ansible/modules/packaging/os/yum.py

The full traceback is:
  File "/tmp/ansible_TEMPi/ansible_module_yum.py", line 264, in <module>
    from yum.misc import find_unfinished_transactions, find_ts_remaining

fatal: [*********]: FAILED! => {
    "changed": false,
    "failed": true,
    "invocation": {
        "module_args": {
            "allow_downgrade": false,
            "conf_file": null,
            "disable_gpg_check": false,
            "disablerepo": null,
            "enablerepo": null,
            "exclude": null,
            "install_repoquery": true,
            "installroot": "/",
            "list": null,
            "name": [
                "docker-python"
            ],
            "security": false,
            "skip_broken": false,
            "state": "present",
            "update_cache": false,
            "validate_certs": true
        }
    },
    "msg": "python2 bindings for rpm are needed for this module. python2 yum module is needed for this  module"
}
```

By the way- thank you @manics for this nice ansible role, it's now working great and of all candidates with SystemD support, it's definitely the best one in the entire universe imho!

Cheers,
Jay