### PR TITLE
Docker registry volume path support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,10 @@ docker_registry_storage_directory: ''
 docker_registry_storage_directory_wait: 0
 
 # Docker registry image version
-docker_registry_version: "2"
+docker_registry_version: '2'
 
 # Listen on this port
 docker_registry_listen_port: 5000
+
+# Registry container name
+docker_registry_container_name: 'docker-registry'

--- a/files/etc/docker/registry/config.yml
+++ b/files/etc/docker/registry/config.yml
@@ -1,0 +1,19 @@
+version: 0.1
+log:
+  fields:
+    service: registry
+storage:
+  cache:
+    blobdescriptor: inmemory
+  filesystem:
+    rootdirectory: /var/lib/registry
+http:
+  addr: :5000
+  headers:
+    X-Content-Type-Options: [nosniff]
+health:
+  storagedriver:
+    enabled: true
+    interval: 10s
+    threshold: 3
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,12 +8,14 @@
     state: directory
   when: 'docker_registry_storage_directory | length > 0'
 
-# Note: Oracle Enterprise Linux doesn't come with the python2 yum & rpm bindings
-# required for the docker_image module.
-- name: docker registry | pull registry image
+- name: docker registry | if not exists, copy config.yml to /etc/docker/registry/
   become: yes
-  shell: docker pull registry:{{ docker_registry_version }}
-  when: ansible_distribution == "OracleLinux"
+  copy:
+    src: files/etc/docker/registry/config.yml
+    dest: /etc/docker/registry/config.yml
+    mode: 0644
+    directory_mode: 0755
+    force: no
 
 # Needed for Ansible docker_image module
 - name: docker registry | docker-python
@@ -29,7 +31,21 @@
     name: registry:{{ docker_registry_version }}
   when: ansible_distribution != "OracleLinux"
 
-- name: docker registry | systemd service file
+- name: docker registry | check for existing registry docker image
+  become: yes
+  shell: docker images -q registry:{{ docker_registry_version }}
+  changed_when: False
+  register: image_check
+  when: ansible_distribution == "OracleLinux"
+
+# Note: Oracle Enterprise Linux doesn't come with the python2 yum & rpm bindings
+# required for the docker_image module.
+- name: docker registry | pull registry image
+  become: yes
+  shell: docker pull registry:{{ docker_registry_version }}
+  when: ansible_distribution == "OracleLinux" and image_check.stdout | length == 0
+
+- name: docker registry | render systemd service template
   become: yes
   template:
     src: systemd-system-docker-registry-service.j2
@@ -38,7 +54,7 @@
   notify:
     - restart docker-registry
 
-- name: docker registry | enable
+- name: docker registry | enable systemd service
   become: yes
   systemd:
     daemon_reload: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,23 +8,33 @@
     state: directory
   when: 'docker_registry_storage_directory | length > 0'
 
+# Note: Oracle Enterprise Linux doesn't come with the python2 yum & rpm bindings
+# required for the docker_image module.
+- name: docker registry | pull registry image
+  become: yes
+  shell: docker pull registry:{{ docker_registry_version }}
+  when: ansible_distribution == "OracleLinux"
+
 # Needed for Ansible docker_image module
 - name: docker registry | docker-python
   become: yes
   yum:
     name: docker-python
     state: present
+  when: ansible_distribution != "OracleLinux"
 
 - name: docker registry | pull registry image
   become: yes
   docker_image:
     name: registry:{{ docker_registry_version }}
+  when: ansible_distribution != "OracleLinux"
 
 - name: docker registry | systemd service file
   become: yes
   template:
     src: systemd-system-docker-registry-service.j2
     dest: /etc/systemd/system/docker-registry.service
+    mode: 0755
   notify:
     - restart docker-registry
 

--- a/templates/systemd-system-docker-registry-service.j2
+++ b/templates/systemd-system-docker-registry-service.j2
@@ -13,7 +13,12 @@ ExecStartPre=-/usr/bin/docker rm docker-registry
 ExecStartPre=/bin/bash -c 'while [ ! -d {{ docker_registry_storage_directory | quote }} ]; do /usr/bin/sleep 5; done'
 TimeoutStartSec={{ docker_registry_storage_directory_wait }}
 {% endif %}
-ExecStart=/usr/bin/docker run --name docker-registry -p {{ docker_registry_listen_port }}:5000 registry:{{ docker_registry_version }}
+ExecStart=/usr/bin/docker run \
+    --name {{ docker_registry_container_name }} \
+    -p {{ docker_registry_listen_port }}:5000 \
+    -v /etc/docker/registry/config.yml:/etc/docker/registry/config.yml \
+    {% if (docker_registry_storage_directory | length > 0) %}-v {{ docker_registry_storage_directory }}:/var/lib/registry{% endif %} \
+    registry:{{ docker_registry_version }}
 ExecStop=/usr/bin/docker stop docker-registry
 
 [Install]


### PR DESCRIPTION
Docker registry volume path support.

* Ensure docker volume config path is propagated through SystemD.
* Support for custom `config.yml` on host system, mounted through -v flag in SystemD script.
* Ansible runs are now clean when nothing has changed.
* "docker-registry" container name is now able to be overridden.
